### PR TITLE
Reconnection management enhancements

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,13 +72,7 @@ socket.monitor = function () {
   
   this.socket.on('error', function (err) {
     if (err.code === 'ECONNREFUSED' || err.code === 'ECONNRESET') {
-      var timeout = this._connectTimeout = setTimeout(function () {
-        self._reconnect();
-      }, delay);
-      
-      delay *= backoff;
-
-      return timeout;
+      return;
     };
     
     throw err;

--- a/index.js
+++ b/index.js
@@ -70,7 +70,7 @@ socket.monitor = function () {
   
   this.socket.on('error', function (err) {
     if (err.code === 'ECONNREFUSED' || err.code === 'ECONNRESET') {
-      return this._connectTimout = setTimeout(function () {
+      return this._connectTimeout = setTimeout(function () {
         self._reconnect();
       }, delay);
       

--- a/index.js
+++ b/index.js
@@ -66,15 +66,19 @@ socket.monitor = function () {
     this._connectTimeout = setTimeout(function () {
       self._reconnect();
     }, delay);
+
+    delay *= backoff;
   });
   
   this.socket.on('error', function (err) {
     if (err.code === 'ECONNREFUSED' || err.code === 'ECONNRESET') {
-      return this._connectTimeout = setTimeout(function () {
+      var timeout = this._connectTimeout = setTimeout(function () {
         self._reconnect();
       }, delay);
       
       delay *= backoff;
+
+      return timeout;
     };
     
     throw err;


### PR DESCRIPTION
Besides the fixes for issues #3 & #4, a couple enhancements have been made.

Once backoff has been reestablished a new problem has appeared: the backoff _increments_ were happening too fast. A first check revealed they happened almost in pairs. The cause is in the fact that a connection loss raises both 'error' and 'close' events.

As per [Node.js docs](https://nodejs.org/api/net.html#net_event_error_1):

> Emitted when an error occurs. The 'close' event will be called directly following this event.

Also, the `_connectTimeout` variable could be overwritten by a new `setTimeout()` without checking if a timeout was already active, leading to parallel reconnect timers from the 'error' and 'close' events.